### PR TITLE
解决Parsedown引入冲突问题

### DIFF
--- a/Plugin.php
+++ b/Plugin.php
@@ -45,7 +45,10 @@ class CustomRSS_Plugin implements Typecho_Plugin_Interface
             ->order('created', Typecho_Db::SORT_DESC)
             ->limit($numOfPosts));
 
-        require_once 'Parsedown.php';
+        // 避免与其他依赖Parsedown的插件共同引入而导致类冲突
+        if (!class_exists('Parsedown')) {
+            require_once 'Parsedown.php';
+        }
         $Parsedown = new Parsedown();
 
         $rssFeed = '<?xml version="1.0" encoding="UTF-8" ?>' . PHP_EOL;


### PR DESCRIPTION
@ibluehe , 非常感谢您提供了使Typecho轻松实现RSS支持的方案 👍

我在启用该插件后遇到了 `Cannot declare class Parsedown, because the name is already in use in use` 的错误，排查发现是 `MarkdownParse` 这个插件也依赖并引入了 `Parsedown.php` ，当 `CustomRSS` 再次尝试引入时便会出现该问题。

稍微加了一个判断，仅当 `Parsedown` 类不存在再尝试 `require_once()` 引入它。